### PR TITLE
Fix system prompt loss during history compaction handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ import (
 )
 
 // Create a session with automatic context compaction
-session := agent.NewSession(
+session, err := agent.NewSession(
     client,
     "You are a helpful assistant",
     agent.WithStore(sqlitestore.New("chat.db")),           // Optional: persist to SQLite
     agent.WithCompactionThreshold(0.8),                    // Compact at 80% full (default)
 )
+if err != nil {
+    log.Fatal(err)
+}
 
 // Use it like a regular Chat
 response, err := session.Message(ctx, chat.Message{

--- a/examples/agent-cli/main.go
+++ b/examples/agent-cli/main.go
@@ -130,7 +130,10 @@ func run(config *Config, input io.Reader, output io.Writer, errOutput io.Writer)
 	}
 
 	// Create a session with automatic context management
-	session := agent.NewSession(client, config.SystemPrompt, sessionOpts...)
+	session, err := agent.NewSession(client, config.SystemPrompt, sessionOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
 	session.SetCompactionThreshold(config.CompactThreshold)
 
 	root, err := os.OpenRoot(".")

--- a/llm/testing/integration.go
+++ b/llm/testing/integration.go
@@ -944,7 +944,8 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 
 	t.Run("SimpleMessages", func(t *testing.T) {
 		// Create a new session with persistence
-		session := agent.NewSession(client, systemPrompt, agent.WithStore(store))
+		session, err := agent.NewSession(client, systemPrompt, agent.WithStore(store))
+		require.NoError(t, err)
 		sessionID := session.SessionID()
 
 		// Baseline record count before first message
@@ -978,9 +979,10 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 		assert.Equal(t, 1, userRecordCount1, "First user message should appear exactly once in persistence")
 
 		// Restore the session from persistence (simulating browser reload)
-		restoredSession := agent.NewSession(client, systemPrompt,
+		restoredSession, err := agent.NewSession(client, systemPrompt,
 			agent.WithStore(store),
 			agent.WithRestoreSession(sessionID))
+		require.NoError(t, err)
 
 		// Send second message on restored session
 		userMsg2 := "What is the capital of France?"
@@ -1022,7 +1024,8 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 
 	t.Run("WithToolCalls", func(t *testing.T) {
 		// Create a new session with persistence and a tool
-		session := agent.NewSession(client, systemPrompt, agent.WithStore(store))
+		session, err := agent.NewSession(client, systemPrompt, agent.WithStore(store))
+		require.NoError(t, err)
 		sessionID := session.SessionID()
 
 		// Register a tool
@@ -1080,9 +1083,10 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 		assert.Equal(t, 1, userRecordCount1, "First user message should appear exactly once")
 
 		// Restore session
-		restoredSession := agent.NewSession(client, systemPrompt,
+		restoredSession, err := agent.NewSession(client, systemPrompt,
 			agent.WithStore(store),
 			agent.WithRestoreSession(sessionID))
+		require.NoError(t, err)
 
 		// Re-register tool on restored session
 		calcTool.callFn = func(ctx context.Context, input string) string {
@@ -1126,7 +1130,8 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 
 	t.Run("EmptyTextMessage", func(t *testing.T) {
 		// Test with a message that has no text (edge case)
-		session := agent.NewSession(client, systemPrompt, agent.WithStore(store))
+		session, err := agent.NewSession(client, systemPrompt, agent.WithStore(store))
+		require.NoError(t, err)
 		sessionID := session.SessionID()
 
 		// Send a normal message first
@@ -1146,9 +1151,10 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 		assert.Equal(t, 1, userRecordCount1, "User message should appear exactly once")
 
 		// Restore and send another message
-		restoredSession := agent.NewSession(client, systemPrompt,
+		restoredSession, err := agent.NewSession(client, systemPrompt,
 			agent.WithStore(store),
 			agent.WithRestoreSession(sessionID))
+		require.NoError(t, err)
 
 		userMsg2 := "Goodbye"
 		_, err = restoredSession.Message(context.Background(), chat.UserMessage(userMsg2))

--- a/llm/testing/integration.go
+++ b/llm/testing/integration.go
@@ -1051,7 +1051,7 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 			},
 		}
 
-		err := session.RegisterTool(calcTool)
+		err = session.RegisterTool(calcTool)
 		require.NoError(t, err)
 
 		baselineRecords, err := store.GetAllRecords(sessionID)
@@ -1136,7 +1136,7 @@ func TestMessagePersistenceAfterRestore(t *testing.T, client chat.Client) {
 
 		// Send a normal message first
 		userMsg1 := "Hello"
-		_, err := session.Message(context.Background(), chat.UserMessage(userMsg1))
+		_, err = session.Message(context.Background(), chat.UserMessage(userMsg1))
 		require.NoError(t, err)
 
 		records1, err := store.GetAllRecords(sessionID)

--- a/session_example_test.go
+++ b/session_example_test.go
@@ -1,3 +1,5 @@
+//go:build sqlite
+
 package agent_test
 
 import (

--- a/session_example_test.go
+++ b/session_example_test.go
@@ -50,12 +50,15 @@ func ExampleSession_resumption() {
 		}
 
 		// Create a new session with persistence
-		session := agent.NewSession(
+		session, err := agent.NewSession(
 			client,
 			"You are a helpful assistant. Remember details about our conversation.",
 			agent.WithStore(store),
 			// We could specify a session ID, but letting it auto-generate is typical
 		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		sessionID := session.SessionID()
 		fmt.Println("Session created")
@@ -99,12 +102,15 @@ func ExampleSession_resumption() {
 		}
 
 		// Resume the previous session
-		session := agent.NewSession(
+		session, err := agent.NewSession(
 			client,
 			"This will be ignored - original prompt is preserved",
 			agent.WithStore(store),
 			agent.WithRestoreSession(sessionID), // Key: restore with the same ID
 		)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		fmt.Println("Session resumed")
 

--- a/session_sqlite_test.go
+++ b/session_sqlite_test.go
@@ -32,9 +32,10 @@ func TestSessionWithSQLiteStore(t *testing.T) {
 
 	// Create session with SQLite persistence
 	client := &mockClient{}
-	session := NewSession(client, "Persistent assistant",
+	session, err := NewSession(client, "Persistent assistant",
 		WithStore(store),
 		WithRestoreSession(sessionID))
+	require.NoError(t, err)
 
 	// Test basic messaging
 	ctx := context.Background()
@@ -52,9 +53,10 @@ func TestSessionWithSQLiteStore(t *testing.T) {
 	assert.Greater(t, metrics.CumulativeTokens, 0)
 
 	// Create new session with same store and session ID to test persistence
-	session2 := NewSession(client, "Should be ignored", // System prompt already in store
+	session2, err := NewSession(client, "Should be ignored", // System prompt already in store
 		WithStore(store),
 		WithRestoreSession(sessionID))
+	require.NoError(t, err)
 
 	// Should have the same records
 	records2 := session2.LiveRecords()
@@ -75,9 +77,10 @@ func TestSessionPersistenceAcrossRestarts(t *testing.T) {
 	require.NoError(t, err)
 
 	client := &mockClient{}
-	session1 := NewSession(client, "Persistent system",
+	session1, err := NewSession(client, "Persistent system",
 		WithStore(store1),
 		WithRestoreSession(sessionID))
+	require.NoError(t, err)
 
 	ctx := context.Background()
 
@@ -98,9 +101,10 @@ func TestSessionPersistenceAcrossRestarts(t *testing.T) {
 	require.NoError(t, err)
 	defer store2.Close()
 
-	session2 := NewSession(client, "Persistent system",
+	session2, err := NewSession(client, "Persistent system",
 		WithStore(store2),
 		WithRestoreSession(sessionID))
+	require.NoError(t, err)
 
 	// Should have the same history
 	records := session2.TotalRecords()
@@ -117,8 +121,9 @@ func TestSessionCompactionWithSQLite(t *testing.T) {
 	defer store.Close()
 
 	client := &mockClient{}
-	session := NewSession(client, "System",
+	session, err := NewSession(client, "System",
 		WithStore(store))
+	require.NoError(t, err)
 
 	// Lower threshold for testing
 	session.SetCompactionThreshold(0.1)
@@ -167,7 +172,8 @@ func TestSessionResumption(t *testing.T) {
 		client := &mockClient{}
 
 		// Create initial session
-		session := NewSession(client, systemPrompt, WithStore(store))
+		session, err := NewSession(client, systemPrompt, WithStore(store))
+		require.NoError(t, err)
 
 		// Record the session ID for later restoration
 		sessionID = session.SessionID()
@@ -212,9 +218,10 @@ func TestSessionResumption(t *testing.T) {
 		client := &mockClient{}
 
 		// Resume session using WithRestoreSession
-		resumedSession := NewSession(client, "Different prompt that should be ignored",
+		resumedSession, err := NewSession(client, "Different prompt that should be ignored",
 			WithStore(store),
 			WithRestoreSession(sessionID))
+		require.NoError(t, err)
 
 		// Verify the session ID matches
 		assert.Equal(t, sessionID, resumedSession.SessionID())
@@ -284,7 +291,8 @@ func TestSessionResumptionWithLLM(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create initial session
-		session := NewSession(client, systemPrompt, WithStore(store))
+		session, err := NewSession(client, systemPrompt, WithStore(store))
+		require.NoError(t, err)
 
 		// Record the session ID for later restoration
 		sessionID = session.SessionID()
@@ -334,9 +342,10 @@ func TestSessionResumptionWithLLM(t *testing.T) {
 		require.NoError(t, err)
 
 		// Resume session using WithRestoreSession
-		resumedSession := NewSession(client, "Different prompt that should be ignored",
+		resumedSession, err := NewSession(client, "Different prompt that should be ignored",
 			WithStore(store),
 			WithRestoreSession(sessionID))
+		require.NoError(t, err)
 
 		// Verify the session ID matches
 		assert.Equal(t, sessionID, resumedSession.SessionID())

--- a/session_sqlite_test.go
+++ b/session_sqlite_test.go
@@ -1,3 +1,5 @@
+//go:build sqlite
+
 package agent
 
 import (

--- a/session_system_reminder_test.go
+++ b/session_system_reminder_test.go
@@ -116,7 +116,8 @@ func TestSessionPreservesSystemReminder(t *testing.T) {
 	t.Parallel()
 
 	client := &mockSystemReminderClient{}
-	session := NewSession(client, "Test system prompt")
+	session, err := NewSession(client, "Test system prompt")
+	require.NoError(t, err)
 
 	// Create context with a system reminder
 	reminderText := "<system-reminder>User is viewing: models/test.sd.json</system-reminder>"
@@ -125,7 +126,7 @@ func TestSessionPreservesSystemReminder(t *testing.T) {
 	})
 
 	// Send a message with the system reminder context
-	_, err := session.Message(ctx, chat.UserMessage("Tell me about this model"))
+	_, err = session.Message(ctx, chat.UserMessage("Tell me about this model"))
 	require.NoError(t, err)
 
 	// Verify that the context with system reminder was seen by the underlying chat
@@ -152,14 +153,15 @@ func TestSessionPreservesSystemReminderAcrossMultipleMessages(t *testing.T) {
 	t.Parallel()
 
 	client := &mockSystemReminderClient{}
-	session := NewSession(client, "Test system prompt")
+	session, err := NewSession(client, "Test system prompt")
+	require.NoError(t, err)
 
 	// First message with system reminder
 	ctx1 := chat.WithSystemReminder(context.Background(), func() string {
 		return "<system-reminder>Viewing: model1.sd.json</system-reminder>"
 	})
 
-	_, err := session.Message(ctx1, chat.UserMessage("First question"))
+	_, err = session.Message(ctx1, chat.UserMessage("First question"))
 	require.NoError(t, err)
 
 	// Second message with different system reminder

--- a/session_tool_persistence_test.go
+++ b/session_tool_persistence_test.go
@@ -209,7 +209,8 @@ func TestSystemReminderPersistence(t *testing.T) {
 	// Now test that Session filters out SystemReminder content when rebuilding history
 	// Create a mock client and session
 	mockClient := &mockClient{}
-	session := NewSession(mockClient, "test system", WithStore(store), WithRestoreSession(sessionID))
+	session, err := NewSession(mockClient, "test system", WithStore(store), WithRestoreSession(sessionID))
+	require.NoError(t, err)
 
 	// Get history - should filter out SystemReminder content
 	_, history := session.History()

--- a/session_tool_persistence_test.go
+++ b/session_tool_persistence_test.go
@@ -1,3 +1,5 @@
+//go:build sqlite
+
 package agent
 
 import (


### PR DESCRIPTION
This commit addresses several critical issues in the session/compaction system:

1. System prompt preservation: compactNowLocked now never marks system role records as dead. The system prompt is critical context that must persist across all compaction cycles. Previously, compaction could mark it dead since it only preserved the last 2 records unconditionally.

2. History rebuild timing: prepareForMessage now builds history AFTER compaction runs, not before. Previously, the triggering request would use pre-compaction history, defeating the purpose of compaction and potentially hitting token limits.

3. Empty message filtering: buildChatHistoryLocked now skips messages that become empty after filtering out SystemReminder content blocks. Claude and other providers reject messages with no content blocks, so this prevents errors when records only contained ephemeral SystemReminder content.

4. Error propagation: NewSession now returns (Session, error) instead of just Session. Store errors from LoadMetrics and GetAllRecords are now propagated to the caller rather than silently ignored. This prevents the session from treating itself as "new" on transient database errors (which could cause duplicate system prompts or divergent history).

All callers have been updated to handle the new error return from NewSession. Tests have been added to verify system prompt preservation across compaction.